### PR TITLE
Use a reader instead of a scanner to handle large responses

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&flags.awsService, "service", "execute-api", "The name of AWS Service, used for signing the request")
 	rootCmd.PersistentFlags().StringVar(&flags.awsRegion, "region", "", "AWS region to use for the request")
 	rootCmd.PersistentFlags().BoolVarP(&flags.insecure, "insecure", "k", false, "Allow insecure server connections when using SSL")
-	rootCmd.PersistentFlags().StringVar(&flags.proxy, "proxy", "", "Proxy to use for the request")
+	rootCmd.PersistentFlags().StringVarP(&flags.proxy, "proxy", "x", "", `Use the specified HTTP proxy, example: -x "<[protocol://][user:password@]proxyhost[:port]>"`)
 
 	rootCmd.Flags().SortFlags = false
 }

--- a/main.go
+++ b/main.go
@@ -146,14 +146,14 @@ func runCurl(cmd *cobra.Command, args []string) error {
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: flags.insecure},
 	}
 
-	// Add proxy if needed
+	// Add proxy settings if needed
 	if flags.proxy != "" {
-		//creating the proxyURL
+		// Parse *urls.URL from the given string
 		proxyURL, err := urls.Parse(flags.proxy)
 		if err != nil {
 			return err
 		}
-		//adding the proxy settings to the Transport object
+
 		tr.Proxy = http.ProxyURL(proxyURL)
 	}
 

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ var rootCmd = &cobra.Command{
 	Use:   "awscurl [URL]",
 	Short: "cURL with AWS request signing",
 	Long: `A simple CLI utility with cURL-like syntax allowing to send HTTP requests to AWS resources.
-It automatically adds Siganture Version 4 to the request. More details:
+It automatically adds Signature Version 4 to the request. More details:
 https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
 `,
 	Args:    cobra.ExactArgs(1),
@@ -150,9 +150,19 @@ func runCurl(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer response.Body.Close()
-	scanner := bufio.NewScanner(response.Body)
-	for scanner.Scan() {
-		fmt.Println(scanner.Text())
+	var line string
+
+	reader := bufio.NewReader(response.Body)
+	for err == nil {
+		line, err = reader.ReadString('\n')
+		if err == nil {
+			fmt.Print(line)
+		}
+	}
+
+	if err != nil && err != io.EOF {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
# Context

When retrieving large responses the software fail to print the response. An hidden error `bufio.Scanner: token too long` is triggered (code added to show the error):

```sh
$ go build && ./awscurl "https://.../v1/potatoes" --profile my-profile
Error: bufio.Scanner: token too long
```

## Implementation

The `scanner` is replaced by a `reader` and text is read line by line with `readString`.

## Test

This has been validated and works i'll send you in PM my testcase.